### PR TITLE
Extend reload to cog

### DIFF
--- a/cogs/system.py
+++ b/cogs/system.py
@@ -112,6 +112,7 @@ class System(commands.Cog):
                 description="Please provide a valid option (reload, add, stop, status).",
                 color=discord.Color.brand_red(),
             )
+            await ctx.reply(embed=embed)
             return
 
         if not cog_name:
@@ -120,6 +121,7 @@ class System(commands.Cog):
                 description="Please provide the name of the cog.",
                 color=discord.Color.brand_red(),
             )
+            await ctx.reply(embed=embed)
             return
 
         cog_path = f"cogs/{cog_name}"

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -125,6 +125,15 @@ class System(commands.Cog):
             await ctx.reply(embed=embed)
             return
 
+        if cog_name == "system" and option is not "reload":
+            error_embed = discord.Embed(
+                title="Cog Blacklisted",
+                description="The 'system' cog is blacklisted since it provides the 'cog' command.",
+                color=discord.Color.brand_red(),
+            )
+            await ctx.reply(embed=error_embed)
+            return
+
         cog_path = f"cogs/{cog_name}"
         if option == "reload":
             if path.exists(f"{cog_path}.py"):

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -79,7 +79,7 @@ class System(commands.Cog):
 
     @commands.command()
     @commands.has_permissions(ban_members=True)
-    async def reload(self, ctx):
+    async def cog(self, ctx, option: str = None, cog_name: str = None):
         """Reloads the Bot cog.
 
         This command reloads the "cogs.music" extension, allowing for updates to take effect.

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -138,12 +138,21 @@ class System(commands.Cog):
                     color=discord.Color.brand_red(),
                 )
 
-        try:
-            # will need to make this work with more cogs once i get that working
-            self.bot.reload_extension("cogs.music")
-            await ctx.reply("Cogs successfully reloaded!")
-        except commands.ExtensionError as err:
-            await ctx.reply(f"An error occurred while reloading the cog: `{err}`")
+        elif option == "start":
+            try:
+                self.bot.load_extension(f"cogs.{cog_name}")
+                embed = discord.Embed(
+                    title="Cog Added",
+                    description=f"The cog `{cog_name}` has been successfully added!",
+                    color=discord.Color.brand_green(),
+                )
+            except commands.ExtensionError as err:
+                embed = discord.Embed(
+                    title="Cog Load Error",
+                    description=f"An error occurred while loading the cog: `{err}`",
+                    color=discord.Color.brand_red(),
+                )
+
 
     @commands.command(aliases=["reboot"])
     @commands.has_permissions(ban_members=True)

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -125,7 +125,7 @@ class System(commands.Cog):
             await ctx.reply(embed=embed)
             return
 
-        if cog_name == "system" and option is not "reload":
+        if cog_name == "system" and option != "reload":
             error_embed = discord.Embed(
                 title="Cog Blacklisted",
                 description="The 'system' cog is blacklisted since it provides the 'cog' command.",

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -94,7 +94,7 @@ class System(commands.Cog):
             cog_name (str, optional): The name of the cog to perform the action on.
         """
         embed = discord.Embed()
-        if option == "status":
+        if option in ["status", None]:
             cogs_status = "\n".join(
                 f"{cog[:-3]:<15} {'✅' if f'cogs.{cog[:-3]}' in self.bot.extensions else '❌'}"
                 for cog in listdir("cogs") if cog.endswith(".py")

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -1,6 +1,6 @@
 from sys import version, argv, executable
 from datetime import datetime
-from os import getpid, execv
+from os import getpid, execv, listdir, path
 
 import discord
 from discord.ext import commands
@@ -168,6 +168,7 @@ class System(commands.Cog):
                     color=discord.Color.brand_red(),
                 )
 
+        await ctx.reply(embed=embed)
 
     @commands.command(aliases=["reboot"])
     @commands.has_permissions(ban_members=True)

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -80,7 +80,7 @@ class System(commands.Cog):
     @commands.command()
     @commands.has_permissions(ban_members=True)
     async def cog(self, ctx, option: str = None, cog_name: str = None):
-        """"Performs actions on a cog or shows cog status.
+        """Performs actions on a cog or shows cog status.
 
         Available options:
         - reload: Reloads the specified cog.

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -80,12 +80,18 @@ class System(commands.Cog):
     @commands.command()
     @commands.has_permissions(ban_members=True)
     async def cog(self, ctx, option: str = None, cog_name: str = None):
-        """Reloads the Bot cog.
+        """"Performs actions on a cog or shows cog status.
 
-        This command reloads the "cogs.music" extension, allowing for updates to take effect.
+        Available options:
+        - reload: Reloads the specified cog.
+        - add: Loads and adds the specified cog.
+        - stop: Unloads and stops the specified cog.
+        - status: Displays the status of all cogs (enabled or not).
 
         Args:
             ctx (discord.ext.commands.Context): The command context.
+            option (str): The action to perform on the cog (reload, add, stop, status).
+            cog_name (str, optional): The name of the cog to perform the action on.
         """
         try:
             # will need to make this work with more cogs once i get that working

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -84,7 +84,7 @@ class System(commands.Cog):
 
         Available options:
         - reload: Reloads the specified cog.
-        - add: Loads and adds the specified cog.
+        - start: Loads and adds the specified cog.
         - stop: Unloads and stops the specified cog.
         - status: Displays the status of all cogs (enabled or not).
 
@@ -93,6 +93,7 @@ class System(commands.Cog):
             option (str): The action to perform on the cog (reload, add, stop, status).
             cog_name (str, optional): The name of the cog to perform the action on.
         """
+        embed = discord.Embed()
         if option == "status":
             cogs_status = "\n".join(
                 f"{cog[:-3]:<15} {'✅' if f'cogs.{cog[:-3]}' in self.bot.extensions else '❌'}"

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -153,6 +153,21 @@ class System(commands.Cog):
                     color=discord.Color.brand_red(),
                 )
 
+        elif option == "stop":
+            if f"cogs.{cog_name}" in self.bot.extensions:
+                self.bot.unload_extension(f"cogs.{cog_name}")
+                embed = discord.Embed(
+                    title="Cog Unloaded",
+                    description=f"The cog `{cog_name}` has been successfully unloaded!",
+                    color=discord.Color.brand_green(),
+                )
+            else:
+                embed = discord.Embed(
+                    title="Cog Not Found",
+                    description=f"The cog `{cog_name}` is not currently loaded.",
+                    color=discord.Color.brand_red(),
+                )
+
 
     @commands.command(aliases=["reboot"])
     @commands.has_permissions(ban_members=True)

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -106,6 +106,22 @@ class System(commands.Cog):
             await ctx.reply(embed=embed)
             return
 
+        if option not in ["reload", "add", "stop", "status"]:
+            embed = discord.Embed(
+                title="Invalid Option",
+                description="Please provide a valid option (reload, add, stop, status).",
+                color=discord.Color.brand_red(),
+            )
+            return
+
+        if not cog_name:
+            embed = discord.Embed(
+                title="Cog Name Missing",
+                description="Please provide the name of the cog.",
+                color=discord.Color.brand_red(),
+            )
+            return
+
         try:
             # will need to make this work with more cogs once i get that working
             self.bot.reload_extension("cogs.music")

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -122,6 +122,22 @@ class System(commands.Cog):
             )
             return
 
+        cog_path = f"cogs/{cog_name}"
+        if option == "reload":
+            if path.exists(f"{cog_path}.py"):
+                self.bot.reload_extension(f"cogs.{cog_name}")
+                embed = discord.Embed(
+                    title="Cog Reloaded",
+                    description=f"The cog `{cog_name}` has been successfully reloaded!",
+                    color=discord.Color.brand_green(),
+                )
+            else:
+                embed = discord.Embed(
+                    title="Cog Not Found",
+                    description=f"The cog `{cog_name}` does not exist.",
+                    color=discord.Color.brand_red(),
+                )
+
         try:
             # will need to make this work with more cogs once i get that working
             self.bot.reload_extension("cogs.music")

--- a/cogs/system.py
+++ b/cogs/system.py
@@ -93,6 +93,19 @@ class System(commands.Cog):
             option (str): The action to perform on the cog (reload, add, stop, status).
             cog_name (str, optional): The name of the cog to perform the action on.
         """
+        if option == "status":
+            cogs_status = "\n".join(
+                f"{cog[:-3]:<15} {'✅' if f'cogs.{cog[:-3]}' in self.bot.extensions else '❌'}"
+                for cog in listdir("cogs") if cog.endswith(".py")
+            )
+            embed = discord.Embed(
+                title="Cog Status",
+                description=f"```\n{cogs_status}\n```",
+                color=discord.Color.blurple(),
+            )
+            await ctx.reply(embed=embed)
+            return
+
         try:
             # will need to make this work with more cogs once i get that working
             self.bot.reload_extension("cogs.music")


### PR DESCRIPTION
Since there are more Cogs now it makes no sense to only support reloading the music cog, while at I implemented Start, stop and status commands:

- Available options:

  - reload: Reloads the specified cog.
  - add: Loads and adds the specified cog.
  - stop: Unloads and stops the specified cog.
  - status: Displays the status of all cogs (enabled or not).
 
**NO MERGE** need to verify some things before I merge
**BLOCKER** Needs Docs update